### PR TITLE
Enhance UCEF extensions privacy

### DIFF
--- a/packages/ucef/contracts/extensions/ERC4626.sol
+++ b/packages/ucef/contracts/extensions/ERC4626.sol
@@ -52,6 +52,26 @@ import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 abstract contract ERC4626 is UCEF, IERC4626 {
     using Math for uint256;
 
+    /**
+    * @notice Deposit event parameter mapping:
+    *   - address param0: caller - Address that initiated the deposit
+    *   - address param1: owner  - Address that owns the shares
+    *   - uint256 param2: assets - Amount of assets deposited
+    *   - uint256 param3: shares - Amount of shares minted
+    * @custom:signature Deposit(address caller, address owner, uint256 assets, uint256 shares)
+    */
+    bytes32 public constant EVENT_TYPE_DEPOSIT = keccak256("Deposit(address,address,uint256,uint256)");
+    /**
+    * @notice Withdraw event parameter mapping:
+    *   - address param0: caller - Address that initiated the withdrawal
+    *   - address param1: receiver - Address that receives the assets
+    *   - address param2: owner - Address that owns the shares
+    *   - uint256 param3: assets - Amount of assets withdrawn
+    *   - uint256 param4: shares - Amount of shares burned
+    * @custom:signature Withdraw(address caller, address receiver, address owner, uint256 assets, uint256 shares)
+    */
+    bytes32 public constant EVENT_TYPE_WITHDRAW = keccak256("Withdraw(address,address,address,uint256,uint256)");
+
     IUCEF private immutable _asset;
     uint8 private immutable _underlyingDecimals;
 
@@ -251,7 +271,7 @@ abstract contract ERC4626 is UCEF, IERC4626 {
         SafeERC20.safeTransferFrom(IUCEF(asset()), caller, address(this), assets);
         _mint(receiver, shares);
 
-        emit Deposit(caller, receiver, assets, shares);
+        _emitDepositEvent(caller, receiver, assets, shares);
     }
 
     /**
@@ -277,7 +297,127 @@ abstract contract ERC4626 is UCEF, IERC4626 {
         _burn(owner, shares);
         SafeERC20.safeTransfer(IUCEF(asset()), receiver, assets);
 
-        emit Withdraw(caller, receiver, owner, assets, shares);
+        _emitWithdrawEvent(caller, receiver, owner, assets, shares);
+    }
+
+    /**
+     * @dev Internal function to emit Deposit events
+     * Can be overridden by derived contracts to implement custom emission logic
+     * Default implementation emits private events with selective visibility
+     * @param caller The address that initiated the deposit
+     * @param receiver The address that receives the shares
+     * @param assets The amount of assets deposited
+     * @param shares The amount of shares minted
+     */
+    function _emitDepositEvent(
+        address caller,
+        address receiver,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual {
+        address[] memory allowedViewers = _getDepositEventViewers(caller, receiver, assets, shares);
+        bytes memory payload = abi.encode(caller, receiver, assets, shares);
+
+        emit PrivateEvent(allowedViewers, EVENT_TYPE_DEPOSIT, payload);
+    }
+
+    /**
+     * @dev Internal function to determine who can view Deposit events
+     * Can be overridden by derived contracts to implement custom viewer logic
+     * Default implementation: only caller and receiver can view
+     * @param caller The address that initiated the deposit
+     * @param receiver The address that receives the shares
+     * @param assets The amount of assets deposited
+     * @param shares The amount of shares minted
+     * @return allowedViewers Array of addresses authorized to view this deposit
+     */
+    function _getDepositEventViewers(
+        address caller,
+        address receiver,
+        uint256 assets,
+        uint256 shares
+    ) internal view virtual returns (address[] memory allowedViewers) {
+        assets; shares; // Available for amount-based vault privacy
+
+        // Count unique non-zero addresses
+        uint256 viewerCount = 0;
+        if (caller != address(0)) viewerCount++;
+        if (receiver != address(0) && receiver != caller) viewerCount++;
+
+        allowedViewers = new address[](viewerCount);
+        uint256 index = 0;
+
+        // Populate viewer list
+        if (caller != address(0)) {
+            allowedViewers[index++] = caller;
+        }
+        if (receiver != address(0) && receiver != caller) {
+            allowedViewers[index] = receiver;
+        }
+    }
+
+    /**
+     * @dev Internal function to emit Withdraw events
+     * Can be overridden by derived contracts to implement custom emission logic
+     * Default implementation emits private events with selective visibility
+     * @param caller The address that initiated the withdrawal
+     * @param receiver The address that receives the assets
+     * @param owner The address that owns the shares being redeemed
+     * @param assets The amount of assets withdrawn
+     * @param shares The amount of shares burned
+     */
+    function _emitWithdrawEvent(
+        address caller,
+        address receiver,
+        address owner,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual {
+        address[] memory allowedViewers = _getWithdrawEventViewers(caller, receiver, owner, assets, shares);
+        bytes memory payload = abi.encode(caller, receiver, owner, assets, shares);
+
+        emit PrivateEvent(allowedViewers, EVENT_TYPE_WITHDRAW, payload);
+    }
+
+    /**
+     * @dev Internal function to determine who can view Withdraw events
+     * Can be overridden by derived contracts to implement custom viewer logic
+     * Default implementation: only caller, receiver, and owner can view
+     * @param caller The address that initiated the withdrawal
+     * @param receiver The address that receives the assets
+     * @param owner The address that owns the shares being redeemed
+     * @param assets The amount of assets withdrawn
+     * @param shares The amount of shares burned
+     * @return allowedViewers Array of addresses authorized to view this withdrawal
+     */
+    function _getWithdrawEventViewers(
+        address caller,
+        address receiver,
+        address owner,
+        uint256 assets,
+        uint256 shares
+    ) internal view virtual returns (address[] memory allowedViewers) {
+        assets; shares; // Available for amount-based vault privacy
+
+        // Count unique non-zero addresses
+        uint256 viewerCount = 0;
+        if (caller != address(0)) viewerCount++;
+        if (receiver != address(0) && receiver != caller) viewerCount++;
+        if (owner != address(0) && owner != caller && owner != receiver) viewerCount++;
+
+        allowedViewers = new address[](viewerCount);
+        uint256 index = 0;
+
+        // Populate viewer list
+        if (caller != address(0)) {
+            allowedViewers[index++] = caller;
+        }
+        if (receiver != address(0) && receiver != caller) {
+            allowedViewers[index++] = receiver;
+        }
+        if (owner != address(0) && owner != caller && owner != receiver) {
+            allowedViewers[index] = owner;
+        }
     }
 
     function _decimalsOffset() internal view virtual returns (uint8) {

--- a/packages/ucef/contracts/extensions/UCEFPausable.sol
+++ b/packages/ucef/contracts/extensions/UCEFPausable.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.20;
 
 import {UCEF} from "../UCEF.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import {AnonymousPausable} from "../utils/AnonymousPausable.sol";
 
 /**
  * @dev ERC-20 token with pausable token transfers, minting and burning.
@@ -19,7 +19,7 @@ import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
  * access control, e.g. using {AccessControl} or {Ownable}. Not doing so will
  * make the contract pause mechanism of the contract unreachable, and thus unusable.
  */
-abstract contract UCEFPausable is UCEF, Pausable {
+abstract contract UCEFPausable is UCEF, AnonymousPausable {
     /**
      * @dev See {ERC20-_update}.
      *

--- a/packages/ucef/contracts/extensions/UCEFVotes.sol
+++ b/packages/ucef/contracts/extensions/UCEFVotes.sol
@@ -4,7 +4,7 @@
 pragma solidity ^0.8.20;
 
 import {UCEF} from "../UCEF.sol";
-import {Votes} from "@openzeppelin/contracts/governance/utils/Votes.sol";
+import {PrivateVotes} from "../utils/PrivateVotes.sol";
 import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
 
 /**
@@ -20,7 +20,7 @@ import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol
  * By default, token balance does not account for voting power. This makes transfers cheaper. The downside is that it
  * requires users to delegate to themselves in order to activate checkpoints and have their voting power tracked.
  */
-abstract contract UCEFVotes is UCEF, Votes {
+abstract contract UCEFVotes is UCEF, PrivateVotes {
     /**
      * @dev Total supply cap has been exceeded, introducing a risk of votes overflowing.
      */

--- a/packages/ucef/contracts/utils/AnonymousPausable.sol
+++ b/packages/ucef/contracts/utils/AnonymousPausable.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+
+/**
+ * @title AnonymousPausable
+ * @dev Contract module which allows children to implement an emergency stop
+ * mechanism that can be triggered by an authorized account with enhanced privacy.
+ *
+ * Based on OpenZeppelin Contracts (last updated v5.3.0) (utils/Pausable.sol)
+ * with modifications for anonymous pause functionality.
+ *
+ * This module is used through inheritance. It will make available the
+ * modifiers `whenNotPaused` and `whenPaused`, which can be applied to
+ * the functions of your contract. Note that they will not be pausable by
+ * simply including this module, only once the modifiers are put in place.
+ *
+ * Key differences from OpenZeppelin's Pausable:
+ * - Pause events emit with address(0) to preserve anonymity of the pause controller
+ * - Maintains transparency about pause state changes while protecting operator privacy
+ * - Virtual event emission functions (_emitPaused, _emitUnpaused) for maximum customization flexibility
+ * - Enables custom event logic without requiring full function overrides or losing state management
+ */
+abstract contract AnonymousPausable is Context {
+    bool private _paused;
+
+    /**
+     * @dev Emitted when the pause is triggered. Account is anonymized for privacy.
+     */
+    event Paused(address account);
+
+    /**
+     * @dev Emitted when the pause is lifted. Account is anonymized for privacy.
+     */
+    event Unpaused(address account);
+
+    /**
+     * @dev The operation failed because the contract is paused.
+     */
+    error EnforcedPause();
+
+    /**
+     * @dev The operation failed because the contract is not paused.
+     */
+    error ExpectedPause();
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is paused.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    /**
+     * @dev Returns true if the contract is paused, and false otherwise.
+     */
+    function paused() public view virtual returns (bool) {
+        return _paused;
+    }
+
+    /**
+     * @dev Throws if the contract is paused.
+     */
+    function _requireNotPaused() internal view virtual {
+        if (paused()) {
+            revert EnforcedPause();
+        }
+    }
+
+    /**
+     * @dev Throws if the contract is not paused.
+     */
+    function _requirePaused() internal view virtual {
+        if (!paused()) {
+            revert ExpectedPause();
+        }
+    }
+
+    /**
+     * @dev Triggers stopped state.
+     *
+     * Requirements:
+     *
+     * - The contract must not be paused.
+     */
+    function _pause() internal virtual whenNotPaused {
+        _paused = true;
+        _emitPaused();
+    }
+
+    /**
+     * @dev Returns to normal state.
+     *
+     * Requirements:
+     *
+     * - The contract must be paused.
+     */
+    function _unpause() internal virtual whenPaused {
+        _paused = false;
+        _emitUnpaused();
+    }
+
+    /**
+     * @dev Emits the Paused event. Can be overridden to customize event emission.
+     * Default implementation emits with address(0) for anonymity.
+     */
+    function _emitPaused() internal virtual {
+        emit Paused(address(0));
+    }
+
+    /**
+     * @dev Emits the Unpaused event. Can be overridden to customize event emission.
+     * Default implementation emits with address(0) for anonymity.
+     */
+    function _emitUnpaused() internal virtual {
+        emit Unpaused(address(0));
+    }
+}

--- a/packages/ucef/contracts/utils/PrivateVotes.sol
+++ b/packages/ucef/contracts/utils/PrivateVotes.sol
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC5805} from "@openzeppelin/contracts/interfaces/IERC5805.sol";
+import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {Nonces} from "@openzeppelin/contracts/utils/Nonces.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import {Checkpoints} from "@openzeppelin/contracts/utils/structs/Checkpoints.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {Time} from "@openzeppelin/contracts/utils/types/Time.sol";
+
+/**
+ * @title PrivateVotes
+ * @dev This is a base abstract contract that tracks voting units with enhanced privacy controls.
+ * It provides a system of vote delegation where events can be emitted privately to authorized viewers.
+ *
+ * Based on OpenZeppelin Contracts (last updated v5.2.0) (governance/utils/Votes.sol)
+ * with modifications for private event functionality.
+ *
+ * This contract provides the same voting and delegation functionality as OpenZeppelin's Votes contract,
+ * but enables customization of event emission through virtual functions. The base functionality includes:
+ * - Vote delegation system where accounts can delegate voting power to representatives
+ * - Historical tracking of voting power through checkpoints
+ * - Protection against flash loans and double voting through on-chain history
+ * - EIP-712 compatible signature-based delegation
+ *
+ * Key differences from OpenZeppelin's Votes:
+ * - Uses Private Events by default for selective visibility of voting activities
+ * - Virtual event emission functions (_emitDelegateChanged, _emitDelegateVotesChanged) for further customization
+ * - Virtual viewer functions (_getDelegateChangedEventViewers, _getDelegateVotesChangedEventViewers) for access control
+ * - Default privacy model: delegators and delegates can view relevant events
+ * - Maintains full interface compatibility with existing governance protocols
+ *
+ * Security considerations:
+ * - Event emission customization should preserve governance transparency requirements
+ * - Private event implementations must ensure authorized viewers include relevant governance participants
+ * - Delegation and voting power changes should remain auditable by appropriate parties
+ * - The checkpoint system integrity must be maintained regardless of event privacy settings
+ *
+ * This contract is often combined with a token contract such that voting units correspond to token units.
+ * The full history of delegate votes is tracked on-chain so that governance protocols can consider votes
+ * as distributed at a particular block number to protect against flash loans and double voting.
+ *
+ * When using this module the derived contract must implement {_getVotingUnits} and can use
+ * {_transferVotingUnits} to track changes in the distribution of voting units.
+ */
+abstract contract PrivateVotes is Context, EIP712, Nonces, IERC5805 {
+    using Checkpoints for Checkpoints.Trace208;
+
+    // Event type constants for Private Events
+    /**
+    * @notice DelegateChanged event parameter mapping:
+    *   - address param0: delegator     - Account that changed its delegation
+    *   - address param1: fromDelegate  - Previous delegate (address(0) if first delegation)
+    *   - address param2: toDelegate    - New delegate (address(0) if removing delegation)
+    * @custom:signature DelegateChanged(address delegator, address fromDelegate, address toDelegate)
+    */
+    bytes32 public constant EVENT_TYPE_DELEGATE_CHANGED = keccak256("DelegateChanged(address,address,address)");
+    
+    /**
+    * @notice DelegateVotesChanged event parameter mapping:
+    *   - address param0: delegate      - Delegate whose vote weight changed
+    *   - uint256 param1: previousVotes - Previous vote weight
+    *   - uint256 param2: newVotes      - New vote weight
+    * @custom:signature DelegateVotesChanged(address delegate, uint256 previousVotes, uint256 newVotes)
+    */
+    bytes32 public constant EVENT_TYPE_DELEGATE_VOTES_CHANGED = keccak256("DelegateVotesChanged(address,uint256,uint256)");
+
+    bytes32 private constant DELEGATION_TYPEHASH =
+        keccak256("Delegation(address delegatee,uint256 nonce,uint256 expiry)");
+
+    mapping(address account => address) private _delegatee;
+
+    mapping(address delegatee => Checkpoints.Trace208) private _delegateCheckpoints;
+
+    Checkpoints.Trace208 private _totalCheckpoints;
+
+    /**
+     * @dev Private Event for selective visibility of voting-related events
+     * @param allowedViewers List of addresses authorized to view the event
+     * @param eventType The keccak256 hash of the original event signature
+     * @param payload The ABI-encoded event arguments
+     */
+    event PrivateEvent(
+        address[] allowedViewers,
+        bytes32 indexed eventType,
+        bytes payload
+    );
+
+    /**
+     * @dev The clock was incorrectly modified.
+     */
+    error ERC6372InconsistentClock();
+
+    /**
+     * @dev Lookup to future votes is not available.
+     */
+    error ERC5805FutureLookup(uint256 timepoint, uint48 clock);
+
+    /**
+     * @dev Clock used for flagging checkpoints. Can be overridden to implement timestamp based
+     * checkpoints (and voting), in which case {CLOCK_MODE} should be overridden as well to match.
+     */
+    function clock() public view virtual returns (uint48) {
+        return Time.blockNumber();
+    }
+
+    /**
+     * @dev Machine-readable description of the clock as specified in ERC-6372.
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function CLOCK_MODE() public view virtual returns (string memory) {
+        // Check that the clock was not modified
+        if (clock() != Time.blockNumber()) {
+            revert ERC6372InconsistentClock();
+        }
+        return "mode=blocknumber&from=default";
+    }
+
+    /**
+     * @dev Validate that a timepoint is in the past, and return it as a uint48.
+     */
+    function _validateTimepoint(uint256 timepoint) internal view returns (uint48) {
+        uint48 currentTimepoint = clock();
+        if (timepoint >= currentTimepoint) revert ERC5805FutureLookup(timepoint, currentTimepoint);
+        return SafeCast.toUint48(timepoint);
+    }
+
+    /**
+     * @dev Returns the current amount of votes that `account` has.
+     */
+    function getVotes(address account) public view virtual returns (uint256) {
+        return _delegateCheckpoints[account].latest();
+    }
+
+    /**
+     * @dev Returns the amount of votes that `account` had at a specific moment in the past. If the `clock()` is
+     * configured to use block numbers, this will return the value at the end of the corresponding block.
+     *
+     * Requirements:
+     *
+     * - `timepoint` must be in the past. If operating using block numbers, the block must be already mined.
+     */
+    function getPastVotes(address account, uint256 timepoint) public view virtual returns (uint256) {
+        return _delegateCheckpoints[account].upperLookupRecent(_validateTimepoint(timepoint));
+    }
+
+    /**
+     * @dev Returns the total supply of votes available at a specific moment in the past. If the `clock()` is
+     * configured to use block numbers, this will return the value at the end of the corresponding block.
+     *
+     * NOTE: This value is the sum of all available votes, which is not necessarily the sum of all delegated votes.
+     * Votes that have not been delegated are still part of total supply, even though they would not participate in a
+     * vote.
+     *
+     * Requirements:
+     *
+     * - `timepoint` must be in the past. If operating using block numbers, the block must be already mined.
+     */
+    function getPastTotalSupply(uint256 timepoint) public view virtual returns (uint256) {
+        return _totalCheckpoints.upperLookupRecent(_validateTimepoint(timepoint));
+    }
+
+    /**
+     * @dev Returns the current total supply of votes.
+     */
+    function _getTotalSupply() internal view virtual returns (uint256) {
+        return _totalCheckpoints.latest();
+    }
+
+    /**
+     * @dev Returns the delegate that `account` has chosen.
+     */
+    function delegates(address account) public view virtual returns (address) {
+        return _delegatee[account];
+    }
+
+    /**
+     * @dev Delegates votes from the sender to `delegatee`.
+     */
+    function delegate(address delegatee) public virtual {
+        address account = _msgSender();
+        _delegate(account, delegatee);
+    }
+
+    /**
+     * @dev Delegates votes from signer to `delegatee`.
+     */
+    function delegateBySig(
+        address delegatee,
+        uint256 nonce,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public virtual {
+        if (block.timestamp > expiry) {
+            revert VotesExpiredSignature(expiry);
+        }
+        address signer = ECDSA.recover(
+            _hashTypedDataV4(keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry))),
+            v,
+            r,
+            s
+        );
+        _useCheckedNonce(signer, nonce);
+        _delegate(signer, delegatee);
+    }
+
+    /**
+     * @dev Delegate all of `account`'s voting units to `delegatee`.
+     *
+     * Emits events {IVotes-DelegateChanged} and {IVotes-DelegateVotesChanged}.
+     */
+    function _delegate(address account, address delegatee) internal virtual {
+        address oldDelegate = delegates(account);
+        _delegatee[account] = delegatee;
+
+        _emitDelegateChanged(account, oldDelegate, delegatee);
+        _moveDelegateVotes(oldDelegate, delegatee, _getVotingUnits(account));
+    }
+
+    /**
+     * @dev Transfers, mints, or burns voting units. To register a mint, `from` should be zero. To register a burn, `to`
+     * should be zero. Total supply of voting units will be adjusted with mints and burns.
+     */
+    function _transferVotingUnits(address from, address to, uint256 amount) internal virtual {
+        if (from == address(0)) {
+            _push(_totalCheckpoints, _add, SafeCast.toUint208(amount));
+        }
+        if (to == address(0)) {
+            _push(_totalCheckpoints, _subtract, SafeCast.toUint208(amount));
+        }
+        _moveDelegateVotes(delegates(from), delegates(to), amount);
+    }
+
+    /**
+     * @dev Moves delegated votes from one delegate to another.
+     */
+    function _moveDelegateVotes(address from, address to, uint256 amount) internal virtual {
+        if (from != to && amount > 0) {
+            if (from != address(0)) {
+                (uint256 oldValue, uint256 newValue) = _push(
+                    _delegateCheckpoints[from],
+                    _subtract,
+                    SafeCast.toUint208(amount)
+                );
+                _emitDelegateVotesChanged(from, oldValue, newValue);
+            }
+            if (to != address(0)) {
+                (uint256 oldValue, uint256 newValue) = _push(
+                    _delegateCheckpoints[to],
+                    _add,
+                    SafeCast.toUint208(amount)
+                );
+                _emitDelegateVotesChanged(to, oldValue, newValue);
+            }
+        }
+    }
+
+    /**
+     * @dev Get number of checkpoints for `account`.
+     */
+    function _numCheckpoints(address account) internal view virtual returns (uint32) {
+        return SafeCast.toUint32(_delegateCheckpoints[account].length());
+    }
+
+    /**
+     * @dev Get the `pos`-th checkpoint for `account`.
+     */
+    function _checkpoints(
+        address account,
+        uint32 pos
+    ) internal view virtual returns (Checkpoints.Checkpoint208 memory) {
+        return _delegateCheckpoints[account].at(pos);
+    }
+
+    function _push(
+        Checkpoints.Trace208 storage store,
+        function(uint208, uint208) view returns (uint208) op,
+        uint208 delta
+    ) private returns (uint208 oldValue, uint208 newValue) {
+        return store.push(clock(), op(store.latest(), delta));
+    }
+
+    function _add(uint208 a, uint208 b) private pure returns (uint208) {
+        return a + b;
+    }
+
+    function _subtract(uint208 a, uint208 b) private pure returns (uint208) {
+        return a - b;
+    }
+
+    /**
+     * @dev Must return the voting units held by an account.
+     */
+    function _getVotingUnits(address) internal view virtual returns (uint256);
+
+    /**
+     * @dev Internal function to emit DelegateChanged events
+     * Can be overridden by derived contracts to implement custom emission logic
+     * Default implementation emits private events with selective visibility
+     * @param delegator The account that changed its delegation
+     * @param fromDelegate The previous delegate (address(0) if this is the first delegation)
+     * @param toDelegate The new delegate (address(0) if delegation is being removed)
+     */
+    function _emitDelegateChanged(address delegator, address fromDelegate, address toDelegate) internal virtual {
+        address[] memory allowedViewers = _getDelegateChangedEventViewers(delegator, fromDelegate, toDelegate);
+        bytes memory payload = abi.encode(delegator, fromDelegate, toDelegate);
+
+        emit PrivateEvent(allowedViewers, EVENT_TYPE_DELEGATE_CHANGED, payload);
+    }
+
+    /**
+     * @dev Internal function to determine who can view DelegateChanged events
+     * Can be overridden by derived contracts to implement custom viewer logic
+     * Default implementation: delegator, old delegate, and new delegate can view
+     * @param delegator The account that changed its delegation
+     * @param fromDelegate The previous delegate
+     * @param toDelegate The new delegate
+     * @return allowedViewers Array of addresses authorized to view this delegation change
+     */
+    function _getDelegateChangedEventViewers(
+        address delegator,
+        address fromDelegate,
+        address toDelegate
+    ) internal view virtual returns (address[] memory allowedViewers) {
+        // Count unique non-zero addresses
+        uint256 viewerCount = 0;
+        if (delegator != address(0)) viewerCount++;
+        if (fromDelegate != address(0) && fromDelegate != delegator) viewerCount++;
+        if (toDelegate != address(0) && toDelegate != delegator && toDelegate != fromDelegate) viewerCount++;
+
+        allowedViewers = new address[](viewerCount);
+        uint256 index = 0;
+
+        // Populate viewer list with unique addresses
+        if (delegator != address(0)) {
+            allowedViewers[index++] = delegator;
+        }
+        if (fromDelegate != address(0) && fromDelegate != delegator) {
+            allowedViewers[index++] = fromDelegate;
+        }
+        if (toDelegate != address(0) && toDelegate != delegator && toDelegate != fromDelegate) {
+            allowedViewers[index] = toDelegate;
+        }
+    }
+
+    /**
+     * @dev Internal function to emit DelegateVotesChanged events
+     * Can be overridden by derived contracts to implement custom emission logic
+     * Default implementation emits private events with selective visibility
+     * @param delegateAddress The delegate whose vote weight changed
+     * @param previousVotes The previous vote weight
+     * @param newVotes The new vote weight
+     */
+    function _emitDelegateVotesChanged(address delegateAddress, uint256 previousVotes, uint256 newVotes) internal virtual {
+        address[] memory allowedViewers = _getDelegateVotesChangedEventViewers(delegateAddress, previousVotes, newVotes);
+        bytes memory payload = abi.encode(delegateAddress, previousVotes, newVotes);
+
+        emit PrivateEvent(allowedViewers, EVENT_TYPE_DELEGATE_VOTES_CHANGED, payload);
+    }
+
+    /**
+     * @dev Internal function to determine who can view DelegateVotesChanged events
+     * Can be overridden by derived contracts to implement custom viewer logic
+     * Default implementation: only the delegate whose vote weight changed can view
+     * @param delegateAddress The delegate whose vote weight changed
+     * @param previousVotes The previous vote weight (available for derived contracts)
+     * @param newVotes The new vote weight (available for derived contracts)
+     * @return allowedViewers Array of addresses authorized to view this vote weight change
+     */
+    function _getDelegateVotesChangedEventViewers(
+        address delegateAddress,
+        uint256 previousVotes,
+        uint256 newVotes
+    ) internal view virtual returns (address[] memory allowedViewers) {
+        previousVotes; // Available for derived contracts
+        newVotes; // Available for derived contracts
+
+        // Only the delegate can view their vote weight changes by default
+        if (delegateAddress != address(0)) {
+            allowedViewers = new address[](1);
+            allowedViewers[0] = delegateAddress;
+        } else {
+            allowedViewers = new address[](0);
+        }
+    }
+}


### PR DESCRIPTION
Adds private events and improves privacy controls for UCEF extensions by replacing standard OpenZeppelin modules with custom implementations that anonymize event emission and restrict event visibility.

### ✨ What's New
- **ERC-4626 Vault Privacy**: Standard `Deposit` and `Withdraw` events replaced with private events using `_emitDepositEvent` and `_emitWithdrawEvent` methods that emit `PrivateEvent` with restricted visibility to authorized viewers only
- **Anonymous Pausing**: `UCEFPausable` now inherits from `AnonymousPausable` instead of OpenZeppelin's `Pausable`, anonymizing the pause controller in event emissions
- **Private Governance**: `UCEFVotes` now inherits from `PrivateVotes` instead of OpenZeppelin's `Votes`, aligning voting logic with privacy requirements

### 🔧 Implementation Details
- Created `AnonymousPausable` utility that emits pause/unpause events with anonymized accounts and provides virtual hooks for customization
- Created `PrivateVotes` utility that provides private event emission for governance operations
- Implemented event viewer function pattern following the established UCEF pattern (`_get*EventViewers`) to determine which addresses can view each event
