### PR TITLE
chore: bump axios override to 1.18.0 to fix audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   ajv@<6.14.0: 6.14.0
   ajv@>=7.0.0 <8.18.0: 8.18.0
-  axios: 1.15.2
+  axios: 1.18.0
   bn.js@<4.12.3: 4.12.3
   bn.js@>=5.0.0 <5.2.3: 5.2.3
   brace-expansion@<1.1.13: 1.1.13
@@ -956,8 +956,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -3670,13 +3670,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.15.2:
+  axios@1.18.0:
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   balanced-match@1.0.2: {}
 
@@ -4118,7 +4120,7 @@ snapshots:
   eth-gas-reporter@0.2.27:
     dependencies:
       '@solidity-parser/parser': 0.14.5
-      axios: 1.15.2
+      axios: 1.18.0
       cli-table3: 0.5.1
       colors: 1.4.0
       ethereum-cryptography: 1.2.0
@@ -4133,6 +4135,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - debug
+      - supports-color
       - utf-8-validate
 
   ethereum-bloom-filters@1.2.0:
@@ -4523,6 +4526,7 @@ snapshots:
       - '@codechecks/client'
       - bufferutil
       - debug
+      - supports-color
       - utf-8-validate
 
   hardhat@2.22.10(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ minimumReleaseAgeExclude:
 overrides:
   'ajv@<6.14.0': '6.14.0'
   'ajv@>=7.0.0 <8.18.0': '8.18.0'
-  axios: '1.15.2'
+  axios: '1.18.0'
   'bn.js@<4.12.3': '4.12.3'
   'bn.js@>=5.0.0 <5.2.3': '5.2.3'
   'brace-expansion@<1.1.13': '1.1.13'


### PR DESCRIPTION
## Summary

Addresses `pnpm audit` findings using minor/patch bumps in the `overrides` section of `pnpm-workspace.yaml`.

**Before:** 6 high, 1 moderate, 2 low.
**After:** 0 high, 0 moderate, 1 low.

## Changes

- **axios** `1.15.2` → `1.18.0` — minor bump (stays on 1.x), resolves all 8 axios advisories, including:
  - high-severity SSRF `NO_PROXY` bypass (CVE-2026-44492)
  - ReDoS via cookie name (GHSA-hfxv-24rg-xrqf)

  Pulled in transitively via `hardhat-gas-reporter > eth-gas-reporter`.

## Not fixed (no upstream patch available)

- **elliptic** `6.6.1` (low, CVE-2025-14505) — the latest published version *is* `6.6.1` and the advisory lists no patched version, so it cannot be resolved via overrides today. It's a dev/tooling-only transitive dep of `@nomicfoundation/hardhat-network-helpers`. To be revisited when upstream ships a fix.

## Verification

- `pnpm install` clean
- `pnpm audit` re-run confirms only the unfixable elliptic low remains