### PR TITLE
Resolve scoped packages from public npm registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,7 +5,6 @@ ignore-scripts=true
 package-manager-strict=true
 
 # Registry configurations
-@appliedblockchain:registry=https://npm.pkg.github.com
-@tokenysolutions:registry=https://npm.pkg.github.com
-@onchain-id:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+# @appliedblockchain, @tokenysolutions and @onchain-id are published on the
+# public npm registry, so they resolve from the default registry. No GitHub
+# Packages auth (GITHUB_TOKEN) is required.


### PR DESCRIPTION
`@appliedblockchain`, `@tokenysolutions` and `@onchain-id` are now on public npm. Removes the obsolete GitHub Packages registry config so install works without a `GITHUB_TOKEN`.